### PR TITLE
Use SOAP1.2 (2003) XML Envelope

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -301,7 +301,8 @@ Server.prototype._envelope = function(body, includeTimestamp) {
     encoding = '',
     alias = findKey(defs.xmlns, ns);
   var xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
-    "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
+//  "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
+    "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" " +
     encoding +
     this.wsdl.xmlnsInEnvelope + '>';
   if (includeTimestamp) {


### PR DESCRIPTION
This is a one line change to use SOAP 1.2 (2003) envelopes which is required for ONVIF

It would probably be better to move things into the latest release of node-soap but for now I just went for the quick fix
