### PR TITLE
Digest Authentication changes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -121,7 +121,7 @@ Server.prototype._requestListener = function(req, res) {
         if (typeof self.log === 'function') {
           self.log("received", xml);
         }
-        self._process(xml, req.url, function (result) {
+        self._process(req, xml, req.url, function (result) {
           res.setHeader('Content-Length', result.length);
           res.write(result);
           res.end();
@@ -131,8 +131,18 @@ Server.prototype._requestListener = function(req, res) {
         });
       }
       catch (err) {
-        error = err.stack || err;
-        res.write(error);
+        if (err.httpHeader) {
+            res.setHeader(err.httpHeader.key, err.httpHeader.value);
+        }
+        if (err.statusCode) {
+          res.statusCode = Number(err.statusCode);
+        }
+        if (err.httpContents) {
+          res.write(err.httpContents);
+        } else {
+          error = err.stack || err
+          res.write(error.toString());
+        }
         res.end();
         if (typeof self.log === 'function') {
           self.log("error", error);
@@ -145,7 +155,7 @@ Server.prototype._requestListener = function(req, res) {
   }
 };
 
-Server.prototype._process = function(input, URL, callback) {
+Server.prototype._process = function(httpRequest, input, URL, callback) {
   var self = this,
     pathname = url.parse(URL).pathname.replace(/\/$/, ''),
     obj = this.wsdl.xmlToObject(input),
@@ -207,7 +217,7 @@ Server.prototype._process = function(input, URL, callback) {
     if (binding.style === 'rpc') {
       methodName = Object.keys(body)[0];
 
-      self.emit('request', obj, methodName);
+      self.emit('request', obj, methodName, httpRequest);
       if (headers)
         self.emit('headers', headers, methodName);
 
@@ -224,7 +234,7 @@ Server.prototype._process = function(input, URL, callback) {
       var messageElemName = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
       var pair = binding.topElements[messageElemName];
 
-      self.emit('request', obj, pair.methodName);
+      self.emit('request', obj, pair.methodName, httpRequest);
       if (headers)
         self.emit('headers', headers, pair.methodName);
 


### PR DESCRIPTION
1) pass the http 'request' to the Parent via the request listener 2) catch a new type of 'throw' with a HTTP Status Code, Header and Contents